### PR TITLE
translate code for Python 3.x compat

### DIFF
--- a/subsample/main.py
+++ b/subsample/main.py
@@ -10,8 +10,8 @@ from itertools import chain
 import logging
 import random
 
-from algorithms import reservoir_sample, approximate_sample, two_pass_sample
-from file_input import FileInput
+from .algorithms import reservoir_sample, approximate_sample, two_pass_sample
+from .file_input import FileInput
 
 logging.basicConfig(level=logging.DEBUG, format='LOG %(asctime)s > %(message)s', datefmt='%H:%M')
 
@@ -57,29 +57,29 @@ def main():
         args.reservoir = True
 
     if args.two_pass and args.input_file == '-':
-        print >> stderr, ('The two-pass algorithm does not support standard input. '
-            'Use another algorithm or save to a file first.')
+        print(('The two-pass algorithm does not support standard input. '
+            'Use another algorithm or save to a file first.'), file=stderr)
         exit(1)
 
     if args.percent is not None and args.fraction is not None:
-        print >> stderr, 'If percent is specified, fraction must not be'
+        print('If percent is specified, fraction must not be', file=stderr)
         exit(1)
 
     if args.percent is not None:
         args.fraction = args.percent / 100
 
     if (args.fraction is not None) and (args.sample_size is not None):
-        print >> stderr, 'If sample size is specified, percent and fraction must not be.'
+        print('If sample size is specified, percent and fraction must not be.', file=stderr)
         exit(1)
 
     if (args.fraction is not None) and args.reservoir:
-        print >> stderr, ('percent and fraction cannot be used with reservoir algorithm; '
-            'use sample size instead.')
+        print(('percent and fraction cannot be used with reservoir algorithm; '
+            'use sample size instead.'), file=stderr)
         exit(1)
 
     if (args.sample_size is not None) and args.approximate:
-        print >> stderr, ('sample size cannot be given with the approximate algorithm; '
-            'use fraction or percent instead.')
+        print(('sample size cannot be given with the approximate algorithm; '
+            'use fraction or percent instead.'), file=stderr)
         exit(1)
 
     fi = FileInput(args.input_file, args.header_rows)
@@ -106,7 +106,7 @@ def main():
         sample = reservoir_sample(fi, args.sample_size)
 
     for line in chain(fi.header, sample):
-        print line,
+        print(line, end=' ')
 
 
 if __name__ == '__main__':

--- a/util/gensource.py
+++ b/util/gensource.py
@@ -7,8 +7,8 @@ def main():
 
     args = parser.parse_args()
 
-    for i in xrange(args.n):
-        print i
+    for i in range(args.n):
+        print(i)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I merely used `2to3` and checked it for sanity. The only bit you might have a problem with is the line 10 of `util/gensource.py` which translated from xrange to range. Since range will build the full list (on 2.X), xrange does make more sense. Then again, 10000 entries will not exhaust anyone's memory these days.

I installed my updates and ran `make test` for python 2.7 and 3.3. They both had identical outputs to your pypi version. (Test reservoir failed across the board.) 
