### PR TITLE
Imported print function for Python 2 compatibility

### DIFF
--- a/subsample/main.py
+++ b/subsample/main.py
@@ -4,6 +4,7 @@ Sample lines from text files (for example, rows of a .csv or .tsv file)
 from the command line.
 '''
 
+from __future__ import print_function
 import argparse
 from sys import stderr
 from itertools import chain


### PR DESCRIPTION
Subsample gives an error on Python >=2.6:

```
$ subsample foo.txt --approximate -f 0.1
...
  File "/Users/anto/Documents/src/subsample/subsample/main.py", line 61
    'Use another algorithm or save to a file first.'), file=stderr)
                                                           ^
SyntaxError: invalid syntax
```

This pull requests corrects the error by importing the print function from `__future__`.
