### PR TITLE
Fixing stdin docs, making fname optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,10 +44,11 @@ to ``big_data_sample.csv``, run the following command::
 Sampling from STDIN
 *******************
 
-To use standard input as the source, use `-` as the filename, eg::
+To use standard input as the source, use `-` as the filename, or do not specify
+any eg::
 
     > subsample -n 1000 - < big_data.csv > big_data_sample.csv
-    > cat big_data.csv | subsample -n 1000 - > big_data_sample.csv
+    > cat big_data.csv | subsample -n 1000 > big_data_sample.csv
 
 Note that only reservoir sampling supports stdin because the other
 sampling algorithms require a seekable input stream.

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,8 @@ Sampling from STDIN
 
 To use standard input as the source, use `-` as the filename, eg::
 
-    > subsample -n 1000 < big_data.csv > big_data_sample.csv
+    > subsample -n 1000 - < big_data.csv > big_data_sample.csv
+    > cat big_data.csv | subsample -n 1000 - > big_data_sample.csv
 
 Note that only reservoir sampling supports stdin because the other
 sampling algorithms require a seekable input stream.

--- a/subsample/main.py
+++ b/subsample/main.py
@@ -24,7 +24,7 @@ PERCENT = 100
 
 def main():
     parser = argparse.ArgumentParser(prog='subsample', description=__doc__)
-    parser.add_argument('input_file', default='-',
+    parser.add_argument('input_file', default='-', nargs="?",
             help='csv, tsv, or other newline-separated data file')
     parser.add_argument('--seed', '-s', type=int, default=None,
             help='random number generator seed, for reproducable results')


### PR DESCRIPTION
Right now the stdin docs does not work:

```
$ subsample -n 1000 < testfile > testfile_out
usage: subsample [-h] [--seed SEED] [--header-rows [HEADER_ROWS]]
             [--percent PERCENT] [--fraction FRACTION]
             [--sample-size SAMPLE_SIZE] [--approximate] [--reservoir]
             [--two-pass]
             input_file
subsample: error: too few arguments
```
